### PR TITLE
Make macros hygienic

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,7 +50,7 @@ macro_rules! track {
         }
     };
     ($target:expr; $($value:expr),+) => {
-        $crate::track!($target, trackable_prepare_values_fmt!($($value),+), $($value),+)
+        $crate::track!($target, $crate::trackable_prepare_values_fmt!($($value),+), $($value),+)
     };
     ($target:expr, $message:expr) => {
         {
@@ -64,7 +64,7 @@ macro_rules! track {
         }
     };
     ($target:expr, $message:expr; $($value:expr),+) => {
-        $crate::track!($target, concat!($message, "; ", trackable_prepare_values_fmt!($($value),+)), $($value),+)
+        $crate::track!($target, concat!($message, "; ", $crate::trackable_prepare_values_fmt!($($value),+)), $($value),+)
     };
     ($target:expr, $($format_arg:tt)+) => {
         {
@@ -157,22 +157,22 @@ macro_rules! track_err {
 macro_rules! track_assert {
     ($cond:expr, $error_kind:expr) => {
         if ! $cond {
-            track_panic!($error_kind, "assertion failed: `{}`", stringify!($cond))
+            $crate::track_panic!($error_kind, "assertion failed: `{}`", stringify!($cond))
         }
     };
     ($cond:expr, $error_kind:expr; $($value:expr),+) => {
-        track_assert!($cond, $error_kind, trackable_prepare_values_fmt!($($value),+), $($value),+)
+        track_assert!($cond, $error_kind, $crate::trackable_prepare_values_fmt!($($value),+), $($value),+)
     };
     ($cond:expr, $error_kind:expr, $message:expr) => {
         track_assert!($cond, $error_kind, $message,)
     };
     ($cond:expr, $error_kind:expr, $message:expr; $($value:expr),+) => {
         track_assert!($cond, $error_kind,
-                      concat!($message, "; ", trackable_prepare_values_fmt!($($value),+)), $($value),+)
+                      concat!($message, "; ", $crate::trackable_prepare_values_fmt!($($value),+)), $($value),+)
     };
     ($cond:expr, $error_kind:expr, $fmt:expr, $($arg:tt)*) => {
         if ! $cond {
-            track_panic!($error_kind,
+            $crate::track_panic!($error_kind,
                          concat!("assertion failed: `{}`; ", $fmt),
                          stringify!($cond), $($arg)*)
         }
@@ -189,27 +189,27 @@ macro_rules! track_assert_eq {
         {
             let left = &$left;
             let right = &$right;
-            track_assert!(left == right, $error_kind,
+            $crate::track_assert!(left == right, $error_kind,
                           "assertion failed: `(left == right)` (left: `{:?}`, right: `{:?}`)",
                           left, right)
         }
     };
     ($left:expr, $right:expr, $error_kind:expr; $($value:expr),+) => {
         track_assert_eq!($left, $right, $error_kind,
-                         trackable_prepare_values_fmt!($($value),+), $($value),+)
+                         $crate::trackable_prepare_values_fmt!($($value),+), $($value),+)
     };
     ($left:expr, $right:expr, $error_kind:expr, $message:expr) => {
         track_assert_eq!($left, $right, $error_kind, $message,)
     };
     ($left:expr, $right:expr, $error_kind:expr, $message:expr; $($value:expr),+) => {
         track_assert_eq!($left, $right, $error_kind,
-                         concat!($message, "; ", trackable_prepare_values_fmt!($($value),+)), $($value),+)
+                         concat!($message, "; ", $crate::trackable_prepare_values_fmt!($($value),+)), $($value),+)
     };
     ($left:expr, $right:expr, $error_kind:expr, $fmt:expr, $($arg:tt)*) => {
         {
             let left = &$left;
             let right = &$right;
-            track_assert!(
+            $crate::track_assert!(
                 left == right, $error_kind,
                 concat!("assertion failed: `(left == right)` (left: `{:?}`, right: `{:?}`): ",
                         $fmt),
@@ -228,27 +228,27 @@ macro_rules! track_assert_ne {
         {
             let left = &$left;
             let right = &$right;
-            track_assert!(left != right, $error_kind,
+            $crate::track_assert!(left != right, $error_kind,
                           "assertion failed: `(left != right)` (left: `{:?}`, right: `{:?}`)",
                           left, right)
         }
     };
     ($left:expr, $right:expr, $error_kind:expr; $($value:expr),+) => {
         track_assert_ne!($left, $right, $error_kind,
-                         trackable_prepare_values_fmt!($($value),+), $($value),+)
+                         $crate::trackable_prepare_values_fmt!($($value),+), $($value),+)
     };
     ($left:expr, $right:expr, $error_kind:expr, $message:expr) => {
         track_assert_ne!($left, $right, $error_kind, $message,)
     };
     ($left:expr, $right:expr, $error_kind:expr, $message:expr; $($value:expr),+) => {
         track_assert_ne!($left, $right, $error_kind,
-                         concat!($message, "; ", trackable_prepare_values_fmt!($($value),+)), $($value),+)
+                         concat!($message, "; ", $crate::trackable_prepare_values_fmt!($($value),+)), $($value),+)
     };
     ($left:expr, $right:expr, $error_kind:expr, $fmt:expr, $($arg:tt)*) => {
         {
             let left = &$left;
             let right = &$right;
-            track_assert!(
+            $crate::track_assert!(
                 left != right, $error_kind,
                 concat!("assertion failed: `(left != right)` (left: `{:?}`, right: `{:?}`): ",
                         $fmt),
@@ -294,25 +294,25 @@ macro_rules! track_assert_some {
         if let Some(v) = $expr {
             v
         } else {
-            track_panic!($error_kind, "assertion failed: `{}.is_some()`", stringify!($expr))
+            $crate::track_panic!($error_kind, "assertion failed: `{}.is_some()`", stringify!($expr))
         }
     };
     ($expr:expr, $error_kind:expr; $($value:expr),+) => {
         track_assert_some!($expr, $error_kind,
-                           trackable_prepare_values_fmt!($($value),+), $($value),+)
+                           $crate::trackable_prepare_values_fmt!($($value),+), $($value),+)
     };
     ($expr:expr, $error_kind:expr, $message:expr) => {
         track_assert_some!($expr, $error_kind, $message,)
     };
     ($expr:expr, $error_kind:expr, $message:expr; $($value:expr),+) => {
         track_assert_some!($expr, $error_kind,
-                           concat!($message, "; ", trackable_prepare_values_fmt!($($value),+)), $($value),+)
+                           concat!($message, "; ", $crate::trackable_prepare_values_fmt!($($value),+)), $($value),+)
     };
     ($expr:expr, $error_kind:expr, $fmt:expr, $($arg:tt)*) => {
         if let Some(v) = $expr {
             v
         } else {
-            track_panic!($error_kind,
+            $crate::track_panic!($error_kind,
                          concat!("assertion failed: `{}.is_some()`; ", $fmt),
                          stringify!($expr), $($arg)*)
         }
@@ -380,7 +380,7 @@ macro_rules! track_panic {
         }
     };
     ($error:expr; $($value:expr),+) => {
-        track_panic!($error, trackable_prepare_values_fmt!($($value),+), $($value),+)
+        track_panic!($error, $crate::trackable_prepare_values_fmt!($($value),+), $($value),+)
     };
     ($error_kind:expr, $message:expr) => {
         {
@@ -390,7 +390,7 @@ macro_rules! track_panic {
     };
     ($error:expr, $message:expr; $($value:expr),+) => {
         track_panic!($error,
-                     concat!($message, "; ", trackable_prepare_values_fmt!($($value),+)), $($value),+)
+                     concat!($message, "; ", $crate::trackable_prepare_values_fmt!($($value),+)), $($value),+)
     };
     ($error_kind:expr, $($format_arg:tt)+) => {
         {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,7 +50,7 @@ macro_rules! track {
         }
     };
     ($target:expr; $($value:expr),+) => {
-        track!($target, trackable_prepare_values_fmt!($($value),+), $($value),+)
+        $crate::track!($target, trackable_prepare_values_fmt!($($value),+), $($value),+)
     };
     ($target:expr, $message:expr) => {
         {
@@ -64,11 +64,11 @@ macro_rules! track {
         }
     };
     ($target:expr, $message:expr; $($value:expr),+) => {
-        track!($target, concat!($message, "; ", trackable_prepare_values_fmt!($($value),+)), $($value),+)
+        $crate::track!($target, concat!($message, "; ", trackable_prepare_values_fmt!($($value),+)), $($value),+)
     };
     ($target:expr, $($format_arg:tt)+) => {
         {
-            track!($target, format!($($format_arg)+))
+            $crate::track!($target, format!($($format_arg)+))
         }
     };
 }
@@ -98,13 +98,13 @@ macro_rules! track {
 #[macro_export]
 macro_rules! track_any_err {
     ($target:expr) => {
-        $target.map_err(|e| track!($crate::error::Failure::from_error(e)))
+        $target.map_err(|e| $crate::track!($crate::error::Failure::from_error(e)))
     };
     ($target:expr; $($arg:tt)*) => {
-        $target.map_err(|e| track!($crate::error::Failure::from_error(e); $($arg)*))
+        $target.map_err(|e| $crate::track!($crate::error::Failure::from_error(e); $($arg)*))
     };
     ($target:expr, $($arg:tt)*) => {
-        $target.map_err(|e| track!($crate::error::Failure::from_error(e), $($arg)*))
+        $target.map_err(|e| $crate::track!($crate::error::Failure::from_error(e), $($arg)*))
     };
 }
 
@@ -112,13 +112,13 @@ macro_rules! track_any_err {
 #[macro_export]
 macro_rules! track_err {
     ($target:expr) => {
-        $target.map_err(|e| track!(e))
+        $target.map_err(|e| $crate::track!(e))
     };
     ($target:expr; $($arg:tt)*) => {
-        $target.map_err(|e| track!(e; $($arg)*))
+        $target.map_err(|e| $crate::track!(e; $($arg)*))
     };
     ($target:expr, $($arg:tt)*) => {
-        $target.map_err(|e| track!(e, $($arg)*))
+        $target.map_err(|e| $crate::track!(e, $($arg)*))
     };
 }
 
@@ -375,7 +375,7 @@ macro_rules! track_panic {
     ($error:expr) => {
         {
             let e = $crate::error::TrackableError::from($error);
-            let e = track!(e);
+            let e = $crate::track!(e);
             return Err(From::from(e));
         }
     };
@@ -424,13 +424,13 @@ macro_rules! track_panic {
 #[macro_export]
 macro_rules! track_try_unwrap {
     ($expr:expr) => {
-        match track!($expr) {
+        match $crate::track!($expr) {
             Err(e) => { panic!("\nEXPRESSION: {}\nERROR: {}\n", stringify!($expr), e) }
             Ok(v) => { v }
         }
     };
     ($expr:expr, $($format_arg:tt)*) => {
-        match track!($expr, $($format_arg)*) {
+        match $crate::track!($expr, $($format_arg)*) {
             Err(e) => { panic!("\nEXPRESSION: {}\nERROR: {}\n", stringify!($expr), e) }
             Ok(v) => { v }
         }


### PR DESCRIPTION
This PR makes all macro invocations in macro definitions hygienic, i.e. explicitly refers to `$crate`.
(ref: https://doc.rust-lang.org/reference/macros-by-example.html#hygiene)

It's confirmed to work with kanils without explicit `extern crate`s and `#[macro_use]`s (https://github.com/frugalos/kanils/compare/tmp/remove-extern-crate). Without this change, this branch won't compile.
However, I'm not sure about whether this is exhaustive (i.e. I've really replaced all such macro invocations). 

By the way, it looks like the 1.0.0 for this crate has already been published to [crates.io](https://crates.io/crates/trackable), but the `master` branch is still on `0.2.23`. Is it a consistent state?