### PR TITLE
Apply semver trick to v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,11 @@ license = "MIT"
 coveralls = {repository = "sile/trackable"}
 
 [dependencies]
-serde = { version = "1", optional = true }
-serde_derive = { version = "1", optional = true }
 trackable1 = { package = "trackable", version = "1.1" }
 trackable_derive = "1"
 
 [features]
-serialize = ["serde", "serde_derive"]
+serialize = ["trackable1/serialize"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ coveralls = {repository = "sile/trackable"}
 [dependencies]
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }
-trackable_derive = "0.1"
+trackable1 = { package = "trackable", version = "1.1" }
+trackable_derive = "1"
 
 [features]
 serialize = ["serde", "serde_derive"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,11 +66,8 @@
 //!
 //! The target error type must be a newtype (i.e., a tuple struct that has a single element) of `TrackableError`.
 use std::error::Error;
-use std::fmt;
-use std::io;
-use std::sync::Arc;
 
-use super::{Location, Trackable};
+use super::Location;
 
 /// Boxed `Error` object.
 pub type BoxError = Box<dyn Error + Send + Sync>;
@@ -81,55 +78,11 @@ pub type BoxErrorKind = Box<dyn ErrorKind + Send + Sync>;
 /// `History` type specialized for `TrackableError`.
 pub type History = ::History<Location>;
 
-/// Built-in `ErrorKind` implementation which represents opaque errors.
-#[derive(Debug, Default, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct Failed;
-impl ErrorKind for Failed {
-    fn description(&self) -> &str {
-        "Failed"
-    }
-}
+pub use trackable1::error::Failed;
 
-/// `TrackableError` type specialized for `Failed`.
-#[derive(Debug, Clone, TrackableError)]
-#[trackable(error_kind = "Failed")]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct Failure(TrackableError<Failed>);
-impl Failure {
-    /// Makes a new `Failure` instance which was caused by the `error`.
-    pub fn from_error<E>(error: E) -> Self
-    where
-        E: Into<BoxError>,
-    {
-        Failed.cause(error).into()
-    }
-}
+pub use trackable1::error::Failure;
 
-/// A variant of `std::io::Error` that implements `Trackable` trait.
-#[derive(Debug, Clone, TrackableError)]
-#[trackable(error_kind = "io::ErrorKind")]
-pub struct IoError(TrackableError<io::ErrorKind>);
-impl From<IoError> for io::Error {
-    fn from(f: IoError) -> Self {
-        io::Error::new(*f.kind(), f)
-    }
-}
-impl From<io::Error> for IoError {
-    fn from(f: io::Error) -> Self {
-        f.kind().cause(f).into()
-    }
-}
-impl From<Failure> for IoError {
-    fn from(f: Failure) -> Self {
-        io::ErrorKind::Other.takes_over(f).into()
-    }
-}
-impl ErrorKind for io::ErrorKind {
-    fn description(&self) -> &str {
-        "I/O Error"
-    }
-}
+pub use trackable1::error::IoError;
 
 /// An `Error` type for unit tests.
 pub type TestError = TopLevelError;
@@ -137,346 +90,13 @@ pub type TestError = TopLevelError;
 /// An `Error` type for `main` function.
 pub type MainError = TopLevelError;
 
-/// An `Error` type for top-level functions.
-pub struct TopLevelError(Box<dyn Error>);
-impl<E: Error + Trackable + 'static> From<E> for TopLevelError {
-    fn from(e: E) -> Self {
-        TopLevelError(Box::new(e))
-    }
-}
-impl fmt::Debug for TopLevelError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-impl fmt::Display for TopLevelError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-impl Error for TopLevelError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&*self.0)
-    }
-}
+pub use trackable1::error::TopLevelError;
 
-/// This trait represents an error kind which `TrackableError` can have.
-pub trait ErrorKind: fmt::Debug {
-    /// A short description of the error kind.
-    ///
-    /// This is used for the description of the error that contains it.
-    ///
-    /// The default implementation always returns `"An error"`.
-    fn description(&self) -> &str {
-        "An error"
-    }
+pub use trackable1::error::ErrorKind;
 
-    /// Displays this kind.
-    ///
-    /// The default implementation uses the debugging form of this.
-    fn display(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-impl ErrorKind for String {
-    fn description(&self) -> &str {
-        self
-    }
-}
+pub use trackable1::error::ErrorKindExt;
 
-/// An extention of `ErrorKind` trait.
-///
-/// This provides convenient functions to create a `TrackableError` instance of this kind.
-pub trait ErrorKindExt: ErrorKind + Sized {
-    /// Makes a `TrackableError` instance without cause.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::error::Error;
-    /// use trackable::error::{Failed, ErrorKindExt};
-    ///
-    /// let e = Failed.error();
-    /// assert!(e.cause().is_none());
-    /// ```
-    #[inline]
-    fn error(self) -> TrackableError<Self> {
-        self.into()
-    }
-
-    /// Makes a `TrackableError` instance with the specified `cause`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::error::Error;
-    /// use trackable::error::{Failed, ErrorKindExt};
-    ///
-    /// let e = Failed.cause("something wrong");
-    /// assert_eq!(e.cause().unwrap().to_string(), "something wrong");
-    /// ```
-    #[inline]
-    fn cause<E>(self, cause: E) -> TrackableError<Self>
-    where
-        E: Into<BoxError>,
-    {
-        TrackableError::new(self, cause.into())
-    }
-
-    /// Takes over from other `TrackableError` instance.
-    ///
-    /// The history of `from` will be preserved.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #[macro_use]
-    /// # extern crate trackable;
-    /// #
-    /// use trackable::error::{ErrorKind, ErrorKindExt};
-    ///
-    /// #[derive(Debug)]
-    /// struct Kind0;
-    /// impl ErrorKind for Kind0 {}
-    ///
-    /// #[derive(Debug)]
-    /// struct Kind1;
-    /// impl ErrorKind for Kind1 {}
-    ///
-    /// fn main() {
-    ///   let e = Kind0.error();
-    ///   let e = track!(e);
-    ///
-    ///   let e = Kind1.takes_over(e);
-    ///   let e = track!(e);
-    ///
-    ///   assert_eq!(format!("\nERROR: {}", e).replace('\\', "/"), r#"
-    /// ERROR: Kind1
-    /// HISTORY:
-    ///   [0] at src/error.rs:17
-    ///   [1] at src/error.rs:20
-    /// "#);
-    /// }
-    /// ```
-    fn takes_over<F, K>(self, from: F) -> TrackableError<Self>
-    where
-        F: Into<TrackableError<K>>,
-        K: ErrorKind + Send + Sync + 'static,
-    {
-        let from = from.into();
-        TrackableError {
-            kind: self,
-            cause: from.cause,
-            history: from.history,
-        }
-    }
-}
-impl<T: ErrorKind> ErrorKindExt for T {}
-
-/// Trackable error.
-///
-/// # Examples
-///
-/// Defines your own `Error` type.
-///
-/// ```
-/// #[macro_use]
-/// extern crate trackable;
-/// use trackable::error::{TrackableError, ErrorKind, ErrorKindExt};
-///
-/// #[derive(Debug, TrackableError)]
-/// #[trackable(error_kind = "MyErrorKind")]
-/// struct MyError(TrackableError<MyErrorKind>);
-/// impl From<std::io::Error> for MyError {
-///     fn from(f: std::io::Error) -> Self {
-///         // Any I/O errors are considered critical
-///         MyErrorKind::Critical.cause(f).into()
-///     }
-/// }
-///
-/// # #[allow(dead_code)]
-/// #[derive(Debug, PartialEq, Eq)]
-/// enum MyErrorKind {
-///     Critical,
-///     NonCritical,
-/// }
-/// impl ErrorKind for MyErrorKind {}
-///
-/// fn main() {
-///     // Tracks an error
-///     let error: MyError = MyErrorKind::Critical.cause("something wrong").into();
-///     let error = track!(error);
-///     let error = track!(error, "I passed here");
-///     assert_eq!(format!("\nError: {}", error).replace('\\', "/"), r#"
-/// Error: Critical (cause; something wrong)
-/// HISTORY:
-///   [0] at src/error.rs:27
-///   [1] at src/error.rs:28 -- I passed here
-/// "#);
-///
-///     // Tries to execute I/O operation
-///     let result = (|| -> Result<_, MyError> {
-///         let f = track!(std::fs::File::open("/path/to/non_existent_file")
-///                        .map_err(MyError::from))?;
-///         Ok(f)
-///     })();
-///     let error = result.err().unwrap();
-///     let cause = error.concrete_cause::<std::io::Error>().unwrap();
-///     assert_eq!(cause.kind(), std::io::ErrorKind::NotFound);
-/// }
-/// ```
-///
-/// `TrackableError` is cloneable if `K` is so.
-///
-/// ```no_run
-/// #[macro_use]
-/// extern crate trackable;
-///
-/// use trackable::Trackable;
-/// use trackable::error::{Failed, ErrorKindExt};
-///
-/// fn main() {
-///     let mut original = Failed.error();
-///
-///     let original = track!(original, "Hello `original`!");
-///     let forked = original.clone();
-///     let forked = track!(forked, "Hello `forked`!");
-///
-///     assert_eq!(format!("\n{}", original).replace('\\', "/"), r#"
-/// Failed
-/// HISTORY:
-///   [0] at src/error.rs:11 -- Hello `original`!
-/// "#);
-///
-///     assert_eq!(format!("\n{}", forked).replace('\\', "/"), r#"
-/// Failed
-/// HISTORY:
-///   [0] at src/error.rs:11 -- Hello `original`!
-///   [1] at src/error.rs:13 -- Hello `forked`!
-/// "#);
-/// }
-/// ```
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct TrackableError<K> {
-    kind: K,
-    cause: Option<Cause>,
-    history: History,
-}
-impl<K: ErrorKind> TrackableError<K> {
-    /// Makes a new `TrackableError` instance.
-    pub fn new<E>(kind: K, cause: E) -> Self
-    where
-        E: Into<BoxError>,
-    {
-        TrackableError {
-            kind,
-            cause: Some(Cause(Arc::new(cause.into()))),
-            history: History::new(),
-        }
-    }
-
-    /// Makes a new `TrackableError` instance from `kind`.
-    ///
-    /// Note that the returning error has no cause.
-    fn from_kind(kind: K) -> Self {
-        TrackableError {
-            kind,
-            cause: None,
-            history: History::new(),
-        }
-    }
-
-    /// Returns the kind of this error.
-    #[inline]
-    pub fn kind(&self) -> &K {
-        &self.kind
-    }
-
-    /// Tries to return the cause of this error as a value of `T` type.
-    ///
-    /// If neither this error has a cause nor it is an `T` value,
-    /// this method will return `None`.
-    #[inline]
-    pub fn concrete_cause<T>(&self) -> Option<&T>
-    where
-        T: Error + 'static,
-    {
-        self.cause.as_ref().and_then(|c| c.0.downcast_ref())
-    }
-}
-impl<K: ErrorKind> From<K> for TrackableError<K> {
-    #[inline]
-    fn from(kind: K) -> Self {
-        Self::from_kind(kind)
-    }
-}
-impl<K: ErrorKind + Default> Default for TrackableError<K> {
-    #[inline]
-    fn default() -> Self {
-        Self::from_kind(K::default())
-    }
-}
-impl<K: ErrorKind> fmt::Display for TrackableError<K> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.kind.display(f)?;
-        if let Some(ref e) = self.cause {
-            write!(f, " (cause; {})", e.0)?;
-        }
-        write!(f, "\n{}", self.history)?;
-        Ok(())
-    }
-}
-impl<K: ErrorKind> Error for TrackableError<K> {
-    fn description(&self) -> &str {
-        self.kind.description()
-    }
-    fn cause(&self) -> Option<&dyn Error> {
-        self.cause.as_ref().map::<&dyn Error, _>(|e| &**e.0)
-    }
-}
-impl<K> Trackable for TrackableError<K> {
-    type Event = Location;
-
-    #[inline]
-    fn history(&self) -> Option<&History> {
-        Some(&self.history)
-    }
-
-    #[inline]
-    fn history_mut(&mut self) -> Option<&mut History> {
-        Some(&mut self.history)
-    }
-}
-
-#[derive(Debug, Clone)]
-struct Cause(Arc<BoxError>);
-
-#[cfg(feature = "serialize")]
-mod impl_serde {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::sync::Arc;
-
-    use super::Cause;
-
-    impl Serialize for Cause {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            serializer.serialize_str(&self.0.to_string())
-        }
-    }
-    impl<'de> Deserialize<'de> for Cause {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let s = String::deserialize(deserializer)?;
-            Ok(Cause(Arc::new(s.into())))
-        }
-    }
-}
+pub use trackable1::error::TrackableError;
 
 #[cfg(test)]
 mod test {
@@ -512,8 +132,8 @@ mod test {
             r#"
 Error: Critical (cause; something wrong)
 HISTORY:
-  [0] at src/error.rs:508
-  [1] at src/error.rs:509 -- I passed here
+  [0] at src/error.rs:131
+  [1] at src/error.rs:132 -- I passed here
 "#
         );
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -132,8 +132,8 @@ mod test {
             r#"
 Error: Critical (cause; something wrong)
 HISTORY:
-  [0] at src/error.rs:131
-  [1] at src/error.rs:132 -- I passed here
+  [0] at src/error.rs:128
+  [1] at src/error.rs:129 -- I passed here
 "#
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,8 @@ extern crate serde;
 #[cfg(feature = "serialize")]
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
+extern crate trackable1;
 extern crate trackable_derive;
-
-use std::borrow::Cow;
-use std::fmt;
 
 #[doc(hidden)]
 pub use trackable_derive::*;
@@ -67,258 +64,11 @@ mod trackable {
 pub mod error;
 pub mod result;
 
-/// This trait allows to track an instance of an implementation type.
-///
-/// A trackable instance can have a tracking history that manages own backtrace-like (but more general)
-/// [history](struct.History.html) for tracking.
-///
-/// You can add entries to the history by calling tracking macros(e.g., [track!](macro.track.html)).
-///
-/// See [`TrackableError`](error/struct.TrackableError.html) as a typical implementaion of this trait.
-///
-/// # Examples
-///
-/// Defines a trackable type.
-///
-/// ```
-/// #[macro_use]
-/// extern crate trackable;
-///
-/// use trackable::{Trackable, History, Location};
-///
-/// #[derive(Default)]
-/// struct TrackableObject {
-///     history: History<Location>,
-/// }
-/// impl Trackable for TrackableObject {
-///     type Event = Location;
-///     fn history(&self) -> Option<&History<Self::Event>> {
-///         Some(&self.history)
-///     }
-///     fn history_mut(&mut self) -> Option<&mut History<Self::Event>> {
-///         Some(&mut self.history)
-///     }
-/// }
-///
-/// fn main() {
-///     let o = TrackableObject::default();
-///     let o = track!(o);
-///     let o = track!(o, "Hello");
-///     let o = track!(o, "Hello {}", "World!");
-///
-///     assert_eq!(format!("\n{}", o.history).replace('\\', "/"), r#"
-/// HISTORY:
-///   [0] at src/lib.rs:23
-///   [1] at src/lib.rs:24 -- Hello
-///   [2] at src/lib.rs:25 -- Hello World!
-/// "#);
-/// }
-/// ```
-pub trait Trackable {
-    /// Event type which a history of an instance of this type can have.
-    type Event: From<Location>;
+pub use trackable1::Trackable;
 
-    /// Add an event into the tail of the history of this instance.
-    ///
-    /// Typically, this is called via [track!](macro.track.html) macro.
-    #[inline]
-    fn track<F>(&mut self, f: F)
-    where
-        F: FnOnce() -> Self::Event,
-    {
-        if let Some(h) = self.history_mut() {
-            h.add(f())
-        }
-    }
+pub use trackable1::History;
 
-    /// Returns `true` if it is being tracked, otherwise `false`.
-    #[inline]
-    fn in_tracking(&self) -> bool {
-        self.history().is_some()
-    }
-
-    /// Returns the reference of the tracking history of this instance.
-    ///
-    /// If it is not being tracked, this will return `None.
-    fn history(&self) -> Option<&History<Self::Event>>;
-
-    /// Returns the mutable reference of the tracking history of this instance.
-    ///
-    /// If it is not being tracked, this will return `None.
-    fn history_mut(&mut self) -> Option<&mut History<Self::Event>>;
-}
-impl<T: Trackable> Trackable for Option<T> {
-    type Event = T::Event;
-
-    #[inline]
-    fn history(&self) -> Option<&History<Self::Event>> {
-        self.as_ref().and_then(Trackable::history)
-    }
-
-    #[inline]
-    fn history_mut(&mut self) -> Option<&mut History<Self::Event>> {
-        self.as_mut().and_then(Trackable::history_mut)
-    }
-}
-impl<T, E: Trackable> Trackable for Result<T, E> {
-    type Event = E::Event;
-
-    #[inline]
-    fn history(&self) -> Option<&History<Self::Event>> {
-        self.as_ref().err().and_then(Trackable::history)
-    }
-
-    #[inline]
-    fn history_mut(&mut self) -> Option<&mut History<Self::Event>> {
-        self.as_mut().err().and_then(Trackable::history_mut)
-    }
-}
-
-/// The tracking history of a target.
-///
-/// A history is a sequence of the tracked events.
-///
-/// # Examples
-///
-/// ```
-/// use std::fmt::{Display, Formatter, Result};
-/// use trackable::History;
-///
-/// struct Event(&'static str);
-/// impl Display for Event {
-///     fn fmt(&self, f: &mut Formatter) -> Result {
-///         write!(f, "event: {}", self.0)
-///     }
-/// }
-///
-/// let mut history = History::new();
-/// history.add(Event("foo"));
-/// history.add(Event("bar"));
-///
-/// assert_eq!(format!("\n{}", history), r#"
-/// HISTORY:
-///   [0] event: foo
-///   [1] event: bar
-/// "#);
-/// ```
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct History<Event>(Vec<Event>);
-impl<Event> History<Event> {
-    /// Makes an empty history.
-    #[inline]
-    pub fn new() -> Self {
-        History(Vec::new())
-    }
-
-    /// Adds an event to the tail of this history.
-    #[inline]
-    pub fn add(&mut self, event: Event) {
-        self.0.push(event);
-    }
-
-    /// Returns the tracked events in this history.
-    #[inline]
-    pub fn events(&self) -> &[Event] {
-        &self.0[..]
-    }
-}
-impl<Event: fmt::Display> fmt::Display for History<Event> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "HISTORY:")?;
-        for (i, e) in self.events().iter().enumerate() {
-            writeln!(f, "  [{}] {}", i, e)?;
-        }
-        Ok(())
-    }
-}
-impl<Event> Default for History<Event> {
-    #[inline]
-    fn default() -> Self {
-        History::new()
-    }
-}
-
-/// The location of interest in source code files.
-///
-/// Typically this is created in the macros which defined in this crate.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-pub struct Location {
-    module_path: Cow<'static, str>,
-    file: Cow<'static, str>,
-    line: u32,
-    message: Cow<'static, str>,
-}
-impl Location {
-    /// Makes a new `Location` instance.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use trackable::Location;
-    ///
-    /// let location = Location::new(module_path!(), file!(), line!(), "Hello".to_string());
-    /// assert_eq!(location.message(), "Hello");
-    /// ```
-    #[inline]
-    pub fn new<M, F, T>(module_path: M, file: F, line: u32, message: T) -> Self
-    where
-        M: Into<Cow<'static, str>>,
-        F: Into<Cow<'static, str>>,
-        T: Into<Cow<'static, str>>,
-    {
-        Location {
-            module_path: module_path.into(),
-            file: file.into(),
-            line,
-            message: message.into(),
-        }
-    }
-
-    /// Gets the crate name of this location.
-    #[inline]
-    pub fn crate_name(&self) -> &str {
-        if let Some(module_path_end) = self.module_path.find(':') {
-            &self.module_path[..module_path_end]
-        } else {
-            self.module_path.as_ref()
-        }
-    }
-
-    /// Gets the module path of this location.
-    #[inline]
-    pub fn module_path(&self) -> &str {
-        self.module_path.as_ref()
-    }
-
-    /// Gets the file name of this location.
-    #[inline]
-    pub fn file(&self) -> &str {
-        self.file.as_ref()
-    }
-
-    /// Gets the line of this location.
-    #[inline]
-    pub fn line(&self) -> u32 {
-        self.line
-    }
-
-    /// Gets the message left at this location.
-    #[inline]
-    pub fn message(&self) -> &str {
-        self.message.as_ref()
-    }
-}
-impl fmt::Display for Location {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "at {}:{}", self.file(), self.line())?;
-        if !self.message().is_empty() {
-            write!(f, " -- {}", self.message())?;
-        }
-        Ok(())
-    }
-}
+pub use trackable1::Location;
 
 #[cfg(test)]
 mod test {
@@ -350,9 +100,9 @@ mod test {
             r#"
 Failed (cause; NotFound)
 HISTORY:
-  [0] at src/lib.rs:331
-  [1] at src/lib.rs:336
-  [2] at src/lib.rs:340
+  [0] at src/lib.rs:86
+  [1] at src/lib.rs:91
+  [2] at src/lib.rs:95
 "#
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,12 +42,8 @@
 //! See the documentaion of [error](error/index.html) module for more details.
 #![warn(missing_docs)]
 
-#[cfg(feature = "serialize")]
-extern crate serde;
-#[cfg(feature = "serialize")]
-#[macro_use]
-extern crate serde_derive;
 extern crate trackable1;
+#[cfg_attr(test, macro_use)]
 extern crate trackable_derive;
 
 #[doc(hidden)]
@@ -100,9 +96,9 @@ mod test {
             r#"
 Failed (cause; NotFound)
 HISTORY:
-  [0] at src/lib.rs:86
-  [1] at src/lib.rs:91
-  [2] at src/lib.rs:95
+  [0] at src/lib.rs:77
+  [1] at src/lib.rs:82
+  [2] at src/lib.rs:86
 "#
         );
     }


### PR DESCRIPTION
This PR applies [the semver trick](https://github.com/dtolnay/semver-trick) to `trackable:0.2.*`.

After this change, all public types in `trackable:0.2.*` refer to those of `trackable:1.>=1.*`. You can have one crate depending on `trackable v0.2` and another on `trackable v1` simultaneously because they export the same types.
Macros in `trackable v0.2` are not affected. I'm not sure, but AFAIK there seems to be no problem.

Proof of concept: `frugalos` compiles with `trackable:0.2.23` (with this change) and `trackable:1.1.0`, both simultaneously in the dependencies.  https://github.com/koba-e964/frugalos/tree/tmp/update-trackable